### PR TITLE
fix: use correct python image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV RMAPIREPO github.com/juruen/rmapi
 RUN git clone https://${RMAPIREPO} && cd rmapi && go install
 
 
-FROM python:3.7-slim-buster
+FROM python:3.9-slim-buster
 
 # rmapi
 COPY --from=rmapi /go/bin/rmapi /usr/bin/rmapi


### PR DESCRIPTION
This PR updates the python version to 3.9 in the Dockerfile, since this is the minimum version according to the setup.py